### PR TITLE
🐛  Fix lodash vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2791,9 +2791,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.14",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-			"integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+			"version": "4.17.19",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 		},
 		"lru-cache": {
 			"version": "5.1.1",
@@ -4831,9 +4831,9 @@
 			}
 		},
 		"yargs-parser": {
-			"version": "13.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-			"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+			"version": "13.1.2",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+			"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
 			"dev": true,
 			"requires": {
 				"camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "webpack-cli": "^3.3.7"
   },
   "dependencies": {
-    "lodash": "^4.17.14",
+    "lodash": "^4.17.19",
     "xml2js": "^0.4.19"
   }
 }


### PR DESCRIPTION
This fixes known `lodash` vulnerabilities for versions < 4.17.16. 
See its [Snyk page](https://snyk.io/vuln/npm:lodash) for details.